### PR TITLE
Audio output tts remake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +482,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +529,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -530,9 +560,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
- "core-graphics-types",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
  "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -543,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -795,6 +836,27 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clonable"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36efbb9bfd58e1723780aa04b61aba95ace6a05d9ffabfdb0b43672552f0805"
+dependencies = [
+ "dyn-clonable-impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "dyn-clonable-impl"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -1058,6 +1120,7 @@ dependencies = [
  "serde",
  "serde_with 2.3.3",
  "time",
+ "tokio",
  "trait_enum",
 ]
 
@@ -1106,6 +1169,7 @@ dependencies = [
  "game_controller_core",
  "game_controller_msgs",
  "game_controller_net",
+ "game_controller_tts",
  "network-interface",
  "serde",
  "serde_repr",
@@ -1114,6 +1178,17 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "game_controller_tts"
+version = "5.0.0-rc.2"
+dependencies = [
+ "anyhow",
+ "speech-dispatcher",
+ "tokio",
+ "tokio-util",
+ "tts",
 ]
 
 [[package]]
@@ -1561,7 +1636,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1978,6 +2053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2257,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
 ]
 
 [[package]]
@@ -2390,6 +2484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2518,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "oxilangtag"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f3f87617a86af77fa3691e6350483e7154c2ead9f1261b75130e21ca0f8acb"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "pango"
@@ -3395,6 +3507,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "speech-dispatcher"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5727d53c474ba5ada07784ad7d203cf896a74854cfee0eb32376b00759eb2972"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "speech-dispatcher-sys",
+]
+
+[[package]]
+name = "speech-dispatcher-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3e8acdf2b1f4bb13f1813b40b52f3edf4cc94d8a55fe713a584f672a10388d"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e59c1f38e657351a2e822eadf40d6a2ad4627b9c25557bc1180ec1b3295ef82"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3530,8 +3662,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -3601,7 +3733,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3686,7 +3818,7 @@ dependencies = [
  "tauri-utils",
  "thiserror 2.0.12",
  "url",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3712,7 +3844,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4067,6 +4199,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tts"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0727c46b3181e4f84e79f970e6a78d3b4054b72b6072e969ea4f07dfa4983ae2"
+dependencies = [
+ "cocoa-foundation",
+ "core-foundation 0.9.4",
+ "dyn-clonable",
+ "jni",
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk-context",
+ "objc",
+ "oxilangtag",
+ "speech-dispatcher",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4409,10 +4564,10 @@ checksum = "b542b5cfbd9618c46c2784e4d41ba218c336ac70d44c55e47b251033e7d85601"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
- "windows-core",
- "windows-implement",
- "windows-interface",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
 ]
 
 [[package]]
@@ -4433,8 +4588,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae2d11c4a686e4409659d7891791254cf9286d3cfe0eef54df1523533d22295"
 dependencies = [
  "thiserror 2.0.12",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4497,12 +4652,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -4514,7 +4679,20 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4523,11 +4701,11 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4536,9 +4714,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4546,6 +4735,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4575,8 +4775,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4586,6 +4795,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4917,8 +5136,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_app"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "anyhow",
  "clap",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_core"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "enum-map",
  "serde",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_logs"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_msgs"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_net"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_runtime"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "anyhow",
  "clap",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "game_controller_tts"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 dependencies = [
  "anyhow",
  "speech-dispatcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ game_controller_core = { path = "game_controller_core" }
 game_controller_msgs = { path = "game_controller_msgs" }
 game_controller_net = { path = "game_controller_net" }
 game_controller_runtime = { path = "game_controller_runtime" }
+game_controller_tts = { path = "game_controller_tts" }
 network-interface = { version = "1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "2.3", features = ["base64", "time_0_3"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "game_controller_logs",
   "game_controller_net",
   "game_controller_runtime",
+  "game_controller_tts",
 ]
 resolver = "2"
 
@@ -27,12 +28,14 @@ serde_with = { version = "2.3", features = ["base64", "time_0_3"] }
 serde_repr = { version = "0.1" }
 serde_yaml = { version = "0.9" }
 socket2 = { version = "0.5", features = ["all"] }
+speech-dispatcher = { version = "0.16.0" }
 tauri = { version = "2.1", features = [] }
 tauri-build = { version = "2.0", features = [] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "serde"] }
 tokio = { version = "1.0", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7" }
 trait_enum = { version = "0.5" }
+tts = { version = "0.26.3" }
 
 [workspace.package]
 authors = ["Arne Hasselbring <arha@uni-bremen.de>"]
@@ -40,7 +43,7 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/RoboCup-SPL/GameController3"
 rust-version = "1.82"
-version = "5.0.0-rc.2"
+version = "5.0.0-rc.2-tts"
 
 [profile.release-dist]
 inherits = "release"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -210,6 +210,42 @@ export const syncWithBackend = async () => {
   }
 };
 
+// press M to toggle mute mode
+// hold spacebar for hold mode
+let mute = false;
+let hold = false;
+
+document.addEventListener('keydown', function(event) {
+  if (event.key == 'm') {
+    mute = !mute;
+    if (window.__TAURI_INTERNALS__) {
+      invoke("set_mute", { mute: mute });
+    } else {
+      console.log("Set mute to " + mute);
+    }
+  }
+  else if (event.key == ' ') {
+    hold = true;
+    if (window.__TAURI_INTERNALS__) {
+      invoke("set_hold", { hold: hold });
+    } else {
+      console.log("Set hold to " + hold);
+    }
+  }
+});
+
+document.addEventListener('keyup', function(event) {
+  if (event.key == ' ') {
+    hold = false;
+    if (window.__TAURI_INTERNALS__) {
+      invoke("set_hold", { hold: hold });
+    } else {
+      console.log("Set hold to " + hold);
+    }
+  }
+});
+
+
 export const applyAction = (action) => {
   if (window.__TAURI_INTERNALS__) {
     invoke("apply_action", { action: action });

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -216,6 +216,7 @@ let mute = false;
 let hold = false;
 
 document.addEventListener('keydown', function(event) {
+  if (event.repeat) return;
   if (event.key == 'm') {
     mute = !mute;
     if (window.__TAURI_INTERNALS__) {
@@ -225,6 +226,7 @@ document.addEventListener('keydown', function(event) {
     }
   }
   else if (event.key == ' ') {
+    event.preventDefault();
     hold = true;
     if (window.__TAURI_INTERNALS__) {
       invoke("set_hold", { hold: hold });
@@ -236,6 +238,7 @@ document.addEventListener('keydown', function(event) {
 
 document.addEventListener('keyup', function(event) {
   if (event.key == ' ') {
+    event.preventDefault();
     hold = false;
     if (window.__TAURI_INTERNALS__) {
       invoke("set_hold", { hold: hold });

--- a/frontend/src/components/Launcher.jsx
+++ b/frontend/src/components/Launcher.jsx
@@ -3,6 +3,7 @@ import CompetitionSettings from "./launcher/CompetitionSettings";
 import GameSettings from "./launcher/GameSettings";
 import NetworkSettings from "./launcher/NetworkSettings";
 import WindowSettings from "./launcher/WindowSettings";
+import TtsSettings from "./launcher/TtsSettings";
 import { getLaunchData, launch } from "../api";
 
 const Launcher = ({ setLaunched }) => {
@@ -10,6 +11,7 @@ const Launcher = ({ setLaunched }) => {
   const [launchSettings, setLaunchSettings] = useState(null);
   const [networkInterfaces, setNetworkInterfaces] = useState(null);
   const [teams, setTeams] = useState(null);
+  const [voices, setVoices] = useState(null);
 
   const launchSettingsAreLegal =
     launchSettings != null &&
@@ -31,6 +33,7 @@ const Launcher = ({ setLaunched }) => {
       setLaunchSettings(data.defaultSettings);
       setNetworkInterfaces(data.networkInterfaces);
       setTeams(data.teams);
+      setVoices(data.voices);
     });
   }, []);
 
@@ -38,7 +41,8 @@ const Launcher = ({ setLaunched }) => {
     competitions != null &&
     launchSettings != null &&
     networkInterfaces != null &&
-    teams != null
+    teams != null &&
+    voices != null
   ) {
     const setCompetition = (competition) => {
       const INVISIBLES_NUMBER = 0;
@@ -69,6 +73,7 @@ const Launcher = ({ setLaunched }) => {
     const teamsInThisCompetition = teams.filter((team) =>
       thisCompetition.teams.includes(team.number)
     );
+    const languages = Object.keys(voices).sort()
     return (
       <div className="flex flex-col items-center p-4 gap-2">
         <CompetitionSettings
@@ -89,6 +94,12 @@ const Launcher = ({ setLaunched }) => {
           interfaces={networkInterfaces}
           network={launchSettings.network}
           setNetwork={(network) => setLaunchSettings({ ...launchSettings, network: network })}
+        />
+        <TtsSettings
+          languages={languages}
+          voices={voices}
+          tts={launchSettings.tts}
+          setTts={(tts) => setLaunchSettings({ ...launchSettings, tts: tts })}
         />
         <button
           className="px-8 py-2 rounded-md border border-black disabled:bg-slate-400"

--- a/frontend/src/components/launcher/TtsSettings.jsx
+++ b/frontend/src/components/launcher/TtsSettings.jsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+const TtsSettings = ({ languages, voices, tts, setTts }) => {
+  const [the_language, set_the_language] = useState("en-US");
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="flex flex-row items-center gap-2">
+        <label>TTS</label>
+        <input
+          type="checkbox"
+          checked={tts.enabled}
+          id="ttsenable"
+          onChange={(e) => setTts({ ...tts, enabled: e.target.checked })}
+        />
+        <label htmlFor="language">language</label>
+        <select
+          id="language"
+          value={the_language}
+          onChange={(e) => {set_the_language(e.target.value); setTts({ ...tts, voice: voices[e.target.value][0]})}}
+        >
+          {languages.map((lang) => (
+            <option key={lang} value={lang}>
+              {lang}
+            </option>
+          ))}
+        </select>
+        <label htmlFor="voice">voice</label>
+        <select
+          id="voice"
+          value={tts.voice}
+          onChange={(e) => setTts({ ...tts, voice: e.target.value })}
+        >
+          {voices[the_language].map((voice) => (
+            <option key={voice} value={voice}>
+              {voice}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default TtsSettings;

--- a/game_controller_app/src/handlers.rs
+++ b/game_controller_app/src/handlers.rs
@@ -117,11 +117,13 @@ fn declare_actions(actions: Vec<VAction>, state: State<RuntimeState>) {
 
 #[command]
 fn set_mute(mute: bool, state: State<RuntimeState>) {
-    println!("Setting mute to {}", mute);
     let _ = state.mute_sender.send(mute);
 }
 
-// TODO set_hold
+#[command]
+fn set_hold(hold: bool, state: State<RuntimeState>) {
+    let _ = state.hold_sender.send(hold);
+}
 
 /// This function returns a handler that can be passed to [tauri::Builder::invoke_handler].
 /// It must be boxed because otherwise its size is unknown at compile time.
@@ -133,5 +135,6 @@ pub fn get_invoke_handler() -> Box<InvokeHandler<Wry>> {
         launch,
         sync_with_backend,
         set_mute,
+        set_hold,
     ])
 }

--- a/game_controller_app/src/handlers.rs
+++ b/game_controller_app/src/handlers.rs
@@ -115,6 +115,14 @@ fn declare_actions(actions: Vec<VAction>, state: State<RuntimeState>) {
     let _ = state.subscribed_actions_sender.send(actions);
 }
 
+#[command]
+fn set_mute(mute: bool, state: State<RuntimeState>) {
+    println!("Setting mute to {}", mute);
+    let _ = state.mute_sender.send(mute);
+}
+
+// TODO set_hold
+
 /// This function returns a handler that can be passed to [tauri::Builder::invoke_handler].
 /// It must be boxed because otherwise its size is unknown at compile time.
 pub fn get_invoke_handler() -> Box<InvokeHandler<Wry>> {
@@ -124,5 +132,6 @@ pub fn get_invoke_handler() -> Box<InvokeHandler<Wry>> {
         get_launch_data,
         launch,
         sync_with_backend,
+        set_mute,
     ])
 }

--- a/game_controller_app/tauri.conf.json
+++ b/game_controller_app/tauri.conf.json
@@ -48,5 +48,5 @@
   "identifier": "org.robocup.spl.game-controller",
   "mainBinaryName": "GameController",
   "productName": "GameController",
-  "version": "5.0.0-rc.2"
+  "version": "5.0.0-rc.2-tts"
 }

--- a/game_controller_core/src/action.rs
+++ b/game_controller_core/src/action.rs
@@ -21,6 +21,14 @@ pub trait Action {
 
     /// This function returns whether the action is legal in the given game state.
     fn is_legal(&self, c: &ActionContext) -> bool;
+
+    /// This function returns the message to be spoken by the TTS system for speakable actions,
+    /// or None if the action is not intended to be announced.
+    fn get_tts_message(&self, _c: &ActionContext) -> Option<String> {
+        // This default None is so that non-speakable actions don't have to worry
+        // about this new addition at all.
+        None
+    }
 }
 
 trait_enum! {

--- a/game_controller_core/src/actions/finish_set_play.rs
+++ b/game_controller_core/src/actions/finish_set_play.rs
@@ -20,4 +20,8 @@ impl Action for FinishSetPlay {
     fn is_legal(&self, c: &ActionContext) -> bool {
         c.game.state == State::Playing && c.game.set_play != SetPlay::NoSetPlay
     }
+
+    fn get_tts_message(&self, _c: &ActionContext) -> Option<String> {
+        Some("Ball free".to_string())
+    }
 }

--- a/game_controller_core/src/actions/global_game_stuck.rs
+++ b/game_controller_core/src/actions/global_game_stuck.rs
@@ -22,4 +22,8 @@ impl Action for GlobalGameStuck {
             && c.game.state == State::Playing
             && c.params.competition.challenge_mode.is_none()
     }
+
+    fn get_tts_message(&self, _c: &ActionContext) -> Option<String> {
+        Some("Global game stuck".to_string())
+    }
 }

--- a/game_controller_core/src/actions/goal.rs
+++ b/game_controller_core/src/actions/goal.rs
@@ -65,4 +65,11 @@ impl Action for Goal {
             && (c.params.competition.challenge_mode.is_none()
                 || self.side == c.params.game.kick_off_side)
     }
+
+    fn get_tts_message(&self, c: &ActionContext) -> Option<String> {
+        Some(format!(
+            "Goal for {}",
+            c.params.game.teams[self.side].field_player_color,
+        ))
+    }
 }

--- a/game_controller_core/src/actions/penalize.rs
+++ b/game_controller_core/src/actions/penalize.rs
@@ -218,4 +218,17 @@ impl Action for Penalize {
                 }
             })
     }
+
+    fn get_tts_message(&self, c: &ActionContext) -> Option<String> {
+        let player_number_str = match self.player {
+            Some(n) => format!("{}", u8::from(n)),
+            None => "Team".to_string(),
+        };
+        Some(format!(
+            "{} {} {}",
+            self.call,
+            c.params.game.teams[self.side].field_player_color,
+            player_number_str
+        ))
+    }
 }

--- a/game_controller_core/src/actions/start_set_play.rs
+++ b/game_controller_core/src/actions/start_set_play.rs
@@ -92,4 +92,24 @@ impl Action for StartSetPlay {
                     && c.params.competition.challenge_mode.is_none()
             })
     }
+
+    fn get_tts_message(&self, c: &ActionContext) -> Option<String> {
+        let side_color_str = match self.side {
+            Some(sd) => {
+                format!("{}", c.params.game.teams[sd].field_player_color)
+            },
+            None => "".to_string(),
+        };
+        let msg = format!(
+            "{} {}",
+            self.set_play,
+            side_color_str,
+        );
+        match self.set_play {
+            SetPlay::KickIn => Some(msg),
+            SetPlay::GoalKick => Some(msg),
+            SetPlay::CornerKick => Some(msg),
+            _ => None,
+        }
+    }
 }

--- a/game_controller_core/src/actions/timeout.rs
+++ b/game_controller_core/src/actions/timeout.rs
@@ -90,4 +90,13 @@ impl Action for Timeout {
                     && c.game.teams[side].timeout_budget > 0
             })
     }
+
+    fn get_tts_message(&self, c: &ActionContext) -> Option<String> {
+        Some(
+            match self.side {
+                Some(sd) => format!("Timeout {}", c.params.game.teams[sd].field_player_color),
+                None => format!("Referee Timeout"),
+            }
+        )
+    }
 }

--- a/game_controller_core/src/actions/unpenalize.rs
+++ b/game_controller_core/src/actions/unpenalize.rs
@@ -32,4 +32,12 @@ impl Action for Unpenalize {
                     && c.game.state == State::Set)
                 || c.params.game.test.unpenalize)
     }
+
+    fn get_tts_message(&self, c: &ActionContext) -> Option<String> {
+        Some(format!(
+            "{} {} returning to field",
+            c.params.game.teams[self.side].field_player_color,
+            u8::from(self.player)
+        ))
+    }
 }

--- a/game_controller_core/src/types.rs
+++ b/game_controller_core/src/types.rs
@@ -213,6 +213,21 @@ pub enum SetPlay {
     PenaltyKick,
 }
 
+impl std::fmt::Display for SetPlay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            Self::NoSetPlay => "No set play",
+            Self::KickOff => "Kick-off",
+            Self::KickIn => "Kick-in",
+            Self::GoalKick => "Goal kick",
+            Self::CornerKick => "Corner kick",
+            Self::PushingFreeKick => "Pushing free kick",
+            Self::PenaltyKick => "Penalty kick",
+        };
+        write!(f, "{output}")
+    }
+}
+
 /// This enumerates the jersey colors. Values may be added to match actually submitted jersey designs.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -227,6 +242,25 @@ pub enum Color {
     Purple,
     Brown,
     Gray,
+}
+
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            Self::Red => "Red",
+            Self::Blue => "Blue",
+            Self::Yellow => "Yellow",
+            Self::Black => "Black",
+            Self::White => "White",
+            Self::Green => "Green",
+            Self::Orange => "Orange",
+            Self::Purple => "Purple",
+            Self::Brown => "Brown",
+            Self::Gray => "Gray",
+        };
+        write!(f, "{output}")
+    }
+
 }
 
 /// This enumerates the reasons why a player can be penalized.
@@ -283,6 +317,27 @@ pub enum PenaltyCall {
     PenaltyKick,
     PlayingWithArmsHands,
     LeavingTheField,
+}
+
+impl std::fmt::Display for PenaltyCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let output = match self {
+            Self::RequestForPickUp => "Request for Pickup",
+            Self::IllegalPosition => "Illegal Position",
+            Self::MotionInStandby => "Motion in Standby",
+            Self::MotionInSet => "Motion in Set",
+            Self::FallenInactive => "Fallen Robot",
+            Self::LocalGameStuck => "Local Game Stuck",
+            Self::BallHolding => "Ball Holding",
+            Self::PlayerStance => "Illegal Stance",
+            Self::Pushing => "Pushing",
+            Self::Foul => "Foul",
+            Self::PenaltyKick => "Penalty Kick",
+            Self::PlayingWithArmsHands => "Playing with Hands",
+            Self::LeavingTheField => "Leaving the Field",
+        };
+        write!(f, "{}", output)
+    }
 }
 
 /// This enumerates the two opposing teams of the game. The name `Side` may be slightly misleading

--- a/game_controller_runtime/Cargo.toml
+++ b/game_controller_runtime/Cargo.toml
@@ -14,6 +14,7 @@ enum-map = { workspace = true }
 game_controller_core = { workspace = true }
 game_controller_msgs = { workspace = true }
 game_controller_net = { workspace = true }
+game_controller_tts = { workspace = true }
 network-interface = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/game_controller_runtime/src/lib.rs
+++ b/game_controller_runtime/src/lib.rs
@@ -499,6 +499,8 @@ pub async fn start_runtime(
 
     runtime_join_set.spawn(tts_event_loop(
         action_ttsmsg_receiver,
+        settings.tts.enabled.clone(),
+        settings.tts.voice.clone(),
         mute_receiver,
         hold_receiver,
         shutdown_token.clone(),

--- a/game_controller_runtime/src/lib.rs
+++ b/game_controller_runtime/src/lib.rs
@@ -91,6 +91,7 @@ pub struct RuntimeState {
     mutable_state: Mutex<MutableState>,
     // for the tts settings
     pub mute_sender: mpsc::UnboundedSender<bool>,
+    pub hold_sender: mpsc::UnboundedSender<bool>,
 }
 
 /// This function starts all network services that are not tied to a specific monitor. It returns a
@@ -483,6 +484,7 @@ pub async fn start_runtime(
     let shutdown_token = CancellationToken::new();
 
     let (mute_sender, mute_receiver) = mpsc::unbounded_channel();
+    let (hold_sender, hold_receiver) = mpsc::unbounded_channel();
 
     runtime_join_set.spawn(event_loop(
         game_controller,
@@ -498,6 +500,7 @@ pub async fn start_runtime(
     runtime_join_set.spawn(tts_event_loop(
         action_ttsmsg_receiver,
         mute_receiver,
+        hold_receiver,
         shutdown_token.clone(),
     ));
 
@@ -512,6 +515,7 @@ pub async fn start_runtime(
             network_join_set,
         }),
         mute_sender,
+        hold_sender,
     })
 }
 

--- a/game_controller_tts/Cargo.toml
+++ b/game_controller_tts/Cargo.toml
@@ -2,15 +2,14 @@
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-name = "game_controller_core"
+name = "game_controller_tts"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-enum-map = { workspace = true }
-serde = { workspace = true }
-serde_with = { workspace = true }
-time = { workspace = true }
+anyhow = { workspace = true }
 tokio = { workspace = true }
-trait_enum = { workspace = true }
+tokio-util = { workspace = true }
+tts = { version = "0.26.3" }
+speech-dispatcher = { version = "0.16.0" }

--- a/game_controller_tts/Cargo.toml
+++ b/game_controller_tts/Cargo.toml
@@ -11,5 +11,5 @@ version = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-tts = { version = "0.26.3" }
-speech-dispatcher = { version = "0.16.0" }
+tts = { workspace = true }
+speech-dispatcher = { workspace = true }

--- a/game_controller_tts/src/lib.rs
+++ b/game_controller_tts/src/lib.rs
@@ -7,79 +7,114 @@
  * should allow a more Rust-savvy contributor greater freedom to apply
  * further improvements, as opposed to cramming this in the game_controller_core.
  * For example, an explicit message queue we have full control over
+ * (as opposed to relying on the system's by passing interrupt:false)
  * would improve HOLD mode, but handling the callback interface offered
  * by the TTS crate proved too tricky for my novice skills.
- * Or maybe, as a minor change, one may want to try a different TTS library:
- * this is as easy as replacing naive_say with whatever functiion you can write.
  */
 
 use tts::*;
 use tokio::{select, sync::mpsc,};
 use tokio_util::sync::CancellationToken;
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+use std::collections::HashMap;
 
-pub fn naive_say(message: String) {
+pub fn get_voices() -> HashMap<String, Vec<String>> {
+    let tts_voices = match Tts::default() {
+        Ok(the_tts) => the_tts.voices().unwrap_or(vec![]),
+        Err(_) => vec![],
+    };
+    let mut voices: HashMap<String, Vec<String>> = HashMap::new();
+    for v in tts_voices {
+        let lang = v.language().as_str().to_string();
+        if !voices.contains_key(&lang) {
+            voices.insert(lang.clone(), vec![]);
+        }
+        let x = voices.get_mut(&lang).unwrap();
+        x.push(v.id());
+    }
+    for (_, x) in voices.iter_mut() {
+        x.sort();
+    }
+    voices
+}
+
+
+fn naive_say(the_tts: &mut Tts, message: &String) {
     println!("Saying: {}", message);
-    let mut the_tts: Tts = Tts::default().unwrap();  // TODO error handling here
     let _ = the_tts.speak(message, false);
 }
 
 pub async fn tts_event_loop(
     mut action_ttsmsg_receiver: mpsc::UnboundedReceiver<Option<String>>,
+    initial_enabled: bool,
+    initial_voice: String,
     mut mute_receiver: mpsc::UnboundedReceiver<bool>,
     mut hold_receiver: mpsc::UnboundedReceiver<bool>,
     shutdown_token: CancellationToken,
 ) -> Result<()> {
-    let mut the_mute = false;
-    let mut the_hold = false;
-    let mut held_messages = vec![];
+    if let Ok(mut the_tts) = Tts::default() {
+        let mut the_mute = !initial_enabled;
+        let mut the_hold = false;
+        let mut held_messages = vec![];
 
-    loop {
-        select! {
-            message_or_error = action_ttsmsg_receiver.recv() => {
-                if let Some(message_or_none) = message_or_error {
-                    if let Some(message) = message_or_none {
-                        println!("Received: {}", message);
-                        if the_mute {
-                            println!("But am mute");
-                        }
-                        else if the_hold {
-                            println!("Holding it");
-                            held_messages.push(message);
-                        }
-                        else {
-                            naive_say(message);
+        for v in the_tts.voices().unwrap() {
+            if v.id() == initial_voice {
+                let _ = the_tts.set_voice(&v);
+            }
+        }
+    
+        loop {
+            select! {
+                message_or_error = action_ttsmsg_receiver.recv() => {
+                    if let Some(message_or_none) = message_or_error {
+                        if let Some(message) = message_or_none {
+                            println!("Received: {}", message);
+                            if the_mute {
+                                println!("But am mute");
+                            }
+                            else if the_hold {
+                                println!("Holding it");
+                                held_messages.push(message);
+                            }
+                            else {
+                                naive_say(&mut the_tts, &message);
+                            }
                         }
                     }
-                }
-            },
-            mute_or_error = mute_receiver.recv() => {
-                if let Some(mute) = mute_or_error {
-                    println!("Set mute to {}", mute);
-                    the_mute = mute;
-                    if mute {
-                        // have mute double as "hold-cancel"
-                        held_messages.clear();
-                    }
-                }
-            },
-            hold_or_error = hold_receiver.recv() => {
-                if let Some(hold) = hold_or_error {
-                    println!("Set hold to {}", hold);
-                    the_hold = hold;
-                    if !hold {
-                        // release all held messages
-                        for i in 0..held_messages.len() {
-                            naive_say(held_messages[i].clone());
+                },
+                mute_or_error = mute_receiver.recv() => {
+                    if let Some(mute) = mute_or_error {
+                        println!("Set mute to {}", mute);
+                        the_mute = mute;
+                        if mute {
+                            let _ = the_tts.stop();
+                            // have mute double as "hold-cancel"
+                            held_messages.clear();
                         }
-                        held_messages.clear();
                     }
-                }
-            },
-            _ = shutdown_token.cancelled() => {
-                return Ok(());
-            },
-        };
+                },
+                hold_or_error = hold_receiver.recv() => {
+                    if let Some(hold) = hold_or_error {
+                        println!("Set hold to {}", hold);
+                        the_hold = hold;
+                        if !hold {
+                            // release all held messages
+                            for i in 0..held_messages.len() {
+                                naive_say(&mut the_tts, &held_messages[i]);
+                            }
+                            held_messages.clear();
+                        }
+                    }
+                },
+                _ = shutdown_token.cancelled() => {
+                    return Ok(());
+                },
+            };
+        }
+    }
+    else {
+        println!("TTS initialization error, will just do without this time");
+        return Err(anyhow!("TTS initialization error"));
     }
 
 }

--- a/game_controller_tts/src/lib.rs
+++ b/game_controller_tts/src/lib.rs
@@ -1,0 +1,62 @@
+/**
+ * Author: Francesco Petri <francesco.petri@uniroma1.it>
+ * 
+ * This file implements the text-to-speech module.
+ * A whole tokio async module is probably a little overkill for how naive
+ * and frontend-assisted this ended up being, but still, this modular structure
+ * should allow a more Rust-savvy contributor greater freedom to apply
+ * further improvements, as opposed to cramming this in the game_controller_core.
+ * For example, an explicit message queue we have full control over
+ * would improve HOLD mode, but handling the callback interface offered
+ * by the TTS crate proved too tricky for my novice skills.
+ * Or maybe, as a minor change, one may want to try a different TTS library:
+ * this is as easy as replacing naive_say with whatever functiion you can write.
+ */
+
+use tts::*;
+use tokio::{select, sync::mpsc,};
+use tokio_util::sync::CancellationToken;
+use anyhow::Result;
+
+pub fn naive_say(message: String) {
+    println!("Saying: {}", message);
+    let mut the_tts: Tts = Tts::default().unwrap();  // TODO error handling here
+    let _ = the_tts.speak(message, false);
+}
+
+pub async fn tts_event_loop(
+    mut action_ttsmsg_receiver: mpsc::UnboundedReceiver<Option<String>>,
+    mut mute_receiver: mpsc::UnboundedReceiver<bool>,
+    shutdown_token: CancellationToken,
+) -> Result<()> {
+    println!("zan zan zan");
+    let mut the_mute = false;
+
+    loop {
+        select! {
+            message_or_error = action_ttsmsg_receiver.recv() => {
+                if let Some(message_or_none) = message_or_error {
+                    if let Some(message) = message_or_none {
+                        println!("Received: {}", message);
+                        if the_mute {
+                            println!("But am mute");
+                        }
+                        else {
+                            naive_say(message);
+                        }
+                    }
+                }
+            },
+            mute_or_error = mute_receiver.recv() => {
+                if let Some(mute) = mute_or_error {
+                    println!("Confirm setting mute to {}", mute);
+                    the_mute = mute;
+                }
+            },
+            _ = shutdown_token.cancelled() => {
+                return Ok(());
+            },
+        };
+    }
+
+}


### PR DESCRIPTION
As promised, I am back with a rewritten version of the text-to-speech extension,

This now runs as a separate module that communicates with the rest of the runtime via `tokio`, resolving some inter-thread communication issues I had encountered with the earlier version.
This still relies on simple TTS backends such as Speech Dispatcher, favoring simplicity over fancy but heavy neural models. *(The modular structure makes it easy for an interested person to use a different Rust library, if so desired. Speech Dispatcher on Linux is also extensible with more advanced voice engines installed on the user's system.)*

What has currently been implemented:
- TTS for penalties, goals and set plays (including ball free)
- Press M to toggle TTS
- Hold Spacebar for "Hold Mode": TTS messages that would be spoken while Space is held are silently queued up, and they are uttered once the key is released.
- Launcher settings for deciding whether TTS starts on or off, and for choosing a voice.

Compilation on Linux requires the development headers for Speech Dispatcher (listed on APT as `libspeechd-dev`, I assume they'll be on other package managers as well).
A compiled Linux build has no extra requirements to run, compared to the "normal" GC.

The `tts` crate description says it is compatible with other text-to-speech backends on other operating systems, so this should work on Windows or Mac with a different setup rather than Speech Dispatcher in theory, but I don't know any specifics as I haven't tested any other OS yet.
Also, note that this branch adds the `tts` crate as a dependency, which should be automatically taken care of by cargo when compiling.